### PR TITLE
fix: eliminación de importación 'map' no utilizada reportada por SonarQube udistrital/sisifo_documentacion#769

### DIFF
--- a/src/app/core/managers/requestManager.ts
+++ b/src/app/core/managers/requestManager.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { catchError, map } from 'rxjs/operators';
+import { catchError } from 'rxjs/operators';
 import { HttpErrorManager } from './errorManager';
 
 import { environment } from '../../../environments/environment';


### PR DESCRIPTION

##  Ajuste: SonarQube (Unused Import)

Se resuelve la issue detectada post-despliegue en SonarQube respecto a la limpieza de operadores de RxJS.

* **Cambio:** Se eliminó la importación de `map` en `requestManager.ts` que quedó huérfana tras la refactorización anterior.
* **Estado:** Con este cambio el archivo queda libre de code smells reportados por la herramienta.

**Vínculo a documentación:** udistrital/sisifo_documentacion#769