### PR TITLE
fix: corrección visual de badge de estado para registros eliminados udistrital/sisifo_documentacion#805

### DIFF
--- a/src/app/modules/gestion-usuarios/consulta-usuarios/consulta-usuarios.component.html
+++ b/src/app/modules/gestion-usuarios/consulta-usuarios/consulta-usuarios.component.html
@@ -158,9 +158,9 @@
                 <td mat-cell *matCellDef="let element">
                   <span
                     class="status-badge"
-                    [ngClass]="element.finalizado ? 'inactive' : 'active'"
+                    [ngClass]="!element.estado ? 'deleted' : (element.finalizado ? 'inactive' : 'active')"
                   >
-                    {{ element.finalizado ? "Finalizado" : "Vigente" }}
+                    {{ !element.estado ? "Eliminado" : (element.finalizado ? "Finalizado" : "Vigente") }}
                   </span>
                 </td>
               </ng-container>

--- a/src/app/modules/gestion-usuarios/consulta-usuarios/consulta-usuarios.component.scss
+++ b/src/app/modules/gestion-usuarios/consulta-usuarios/consulta-usuarios.component.scss
@@ -35,6 +35,11 @@
     background-color: #f9eaf1;
     color: var(--md-warning-500);
   }
+
+  &.deleted {
+    background-color: #ef9a9a;
+    color: #b71c1c;
+  }
 }
 
 .link {


### PR DESCRIPTION
# Corrección badge de estado en periodos eliminados

## Descripción
Se corrige la lógica visual del badge de estado en la tabla de periodos, ya que los registros eliminados mediante soft delete continuaban mostrándose como `Vigente`.

## Problema identificado

El frontend determinaba el estado únicamente usando el campo `finalizado`, ignorando el campo `activo` enviado por el CRUD.

Esto provocaba que registros con:

```txt
activo = false
```

continuaran visualizándose como activos.

## Cambios realizados

- Se agregó `element.estado` como primera validación del badge.
- Se definió la jerarquía visual:

| activo | finalizado | Estado |
|---|---|---|
| false | cualquier valor | Eliminado |
| true | true | Finalizado |
| true | false | Vigente |

- Se actualizaron:
  - clases CSS dinámicas (`ngClass`)
  - texto mostrado en el badge

## Resultado

Los registros eliminados ahora reflejan correctamente el estado `Eliminado` en la interfaz.

## Pruebas realizadas

- Validación visual de registros activos.
- Validación visual de registros finalizados.
- Validación visual de registros eliminados mediante soft delete.